### PR TITLE
FRM-255 - Bug fix 

### DIFF
--- a/packages/core/src/app/checkout/dealer/DealerShipping.tsx
+++ b/packages/core/src/app/checkout/dealer/DealerShipping.tsx
@@ -843,7 +843,7 @@ class DealerShipping extends React.PureComponent<
         )}
 
         {/* ========== Address Selector for Logged-in Users with Ammo ========== */}
-        {!customer.isGuest && this.hasOnlyAmmunition() && (
+        {!customer.isGuest && this.hasOnlyAmmunition() && !this.state.bypassFFL && (
           <div className="ammo-address-selector">
             <legend className="optimizedCheckout-headingSecondary" style={{ marginBottom: '5px' }}>
               Select Shipping Address


### PR DESCRIPTION
for when a logged in customer with ammo in the cart (but not firearms) selects an FFL required address and then selects bypass. We now hide the original address selector since the new form will also have an address selector.
